### PR TITLE
feat: add category management for blog posts

### DIFF
--- a/apps/studio/schemaTypes/documents/blog.ts
+++ b/apps/studio/schemaTypes/documents/blog.ts
@@ -134,6 +134,23 @@ export const blog = defineType({
         "The main content of your blog post with text, images, and formatting",
       group: GROUP.MAIN_CONTENT,
     }),
+    defineField({
+      name: "categories",
+      type: "array",
+      title: "Categories",
+      description: "Select one or more categories for this blog post",
+      of: [
+        defineArrayMember({
+          type: "reference",
+          to: [{ type: "category" }],
+          options: {
+            disableNew: true,
+          },
+        }),
+      ],
+      validation: (Rule) => Rule.min(1).error("At least one category is required"),
+      group: GROUP.MAIN_CONTENT,
+    }),
     ...seoFields,
     ...ogFields,
   ],

--- a/apps/studio/schemaTypes/documents/category.ts
+++ b/apps/studio/schemaTypes/documents/category.ts
@@ -1,0 +1,79 @@
+import { defineField, defineType } from "sanity";
+import { TagIcon } from "lucide-react";
+
+import { GROUP, GROUPS } from "../../utils/constant";
+import { createSlug, isUnique } from "../../utils/slug";
+
+export const category = defineType({
+  name: "category",
+  title: "Category",
+  type: "document",
+  icon: TagIcon,
+  groups: GROUPS,
+  description: "A category for organizing blog posts by topic or theme.",
+  fields: [
+    defineField({
+      name: "name",
+      type: "string",
+      title: "Category Name",
+      description: "The name of the category (e.g., 'Sanity', 'Next.js', 'Web Development')",
+      group: GROUP.MAIN_CONTENT,
+      validation: (Rule) => Rule.required().error("A category name is required"),
+    }),
+    defineField({
+      name: "description",
+      type: "text",
+      title: "Description",
+      description: "A brief description of what this category is about",
+      group: GROUP.MAIN_CONTENT,
+      rows: 3,
+    }),
+    defineField({
+      name: "slug",
+      type: "slug",
+      title: "URL Slug",
+      description: "The URL-friendly version of the category name (e.g., 'sanity', 'nextjs')",
+      group: GROUP.MAIN_CONTENT,
+      options: {
+        source: "name",
+        slugify: createSlug,
+        isUnique,
+      },
+      validation: (Rule) => Rule.required().error("A URL slug is required"),
+    }),
+    defineField({
+      name: "color",
+      type: "string",
+      title: "Category Color",
+      description: "A color to represent this category in the UI",
+      group: GROUP.MAIN_CONTENT,
+      options: {
+        list: [
+          { title: "Blue", value: "blue" },
+          { title: "Green", value: "green" },
+          { title: "Purple", value: "purple" },
+          { title: "Orange", value: "orange" },
+          { title: "Red", value: "red" },
+          { title: "Yellow", value: "yellow" },
+          { title: "Pink", value: "pink" },
+          { title: "Indigo", value: "indigo" },
+        ],
+        layout: "dropdown",
+      },
+      initialValue: "blue",
+    }),
+  ],
+  preview: {
+    select: {
+      title: "name",
+      description: "description",
+      color: "color",
+      slug: "slug.current",
+    },
+    prepare: ({ title, description, color, slug }) => ({
+      title: title || "Untitled Category",
+      subtitle: description || slug || "No description",
+      media: TagIcon,
+    }),
+  },
+});

--- a/apps/studio/schemaTypes/documents/index.ts
+++ b/apps/studio/schemaTypes/documents/index.ts
@@ -1,6 +1,7 @@
 import { author } from "./author";
 import { blog } from "./blog";
 import { blogIndex } from "./blog-index";
+import { category } from "./category";
 import { faq } from "./faq";
 import { footer } from "./footer";
 import { homePage } from "./home-page";
@@ -10,4 +11,4 @@ import { settings } from "./settings";
 
 export const singletons = [homePage, blogIndex, settings, footer, navbar];
 
-export const documents = [blog, page, faq, author, ...singletons];
+export const documents = [blog, page, faq, author, category, ...singletons];

--- a/apps/studio/scripts/create-categories.ts
+++ b/apps/studio/scripts/create-categories.ts
@@ -1,0 +1,67 @@
+import { createClient } from '@sanity/client';
+
+const client = createClient({
+  projectId: 'your-project-id', // Replace with your actual project ID
+  dataset: 'production',
+  apiVersion: '2024-01-01',
+  useCdn: false,
+  token: process.env.SANITY_TOKEN, // You'll need to set this environment variable
+});
+
+const sampleCategories = [
+  {
+    _type: 'category',
+    name: 'Sanity',
+    description: 'Content management and development with Sanity CMS',
+    slug: { current: 'sanity' },
+    color: 'blue',
+  },
+  {
+    _type: 'category',
+    name: 'Next.js',
+    description: 'React framework for production applications',
+    slug: { current: 'nextjs' },
+    color: 'green',
+  },
+  {
+    _type: 'category',
+    name: 'Web Development',
+    description: 'General web development topics and tutorials',
+    slug: { current: 'web-development' },
+    color: 'purple',
+  },
+  {
+    _type: 'category',
+    name: 'Design',
+    description: 'UI/UX design principles and best practices',
+    slug: { current: 'design' },
+    color: 'orange',
+  },
+  {
+    _type: 'category',
+    name: 'Performance',
+    description: 'Website performance optimization and best practices',
+    slug: { current: 'performance' },
+    color: 'red',
+  },
+];
+
+async function createCategories() {
+  try {
+    console.log('Creating sample categories...');
+    
+    for (const category of sampleCategories) {
+      const result = await client.create(category);
+      console.log(`Created category: ${result.name} (${result._id})`);
+    }
+    
+    console.log('All categories created successfully!');
+  } catch (error) {
+    console.error('Error creating categories:', error);
+  }
+}
+
+// Only run if this file is executed directly
+if (require.main === module) {
+  createCategories();
+}

--- a/apps/studio/scripts/create-data.ts
+++ b/apps/studio/scripts/create-data.ts
@@ -18,6 +18,7 @@ import {
   generateFAQs,
   generateMockAuthors,
   generateMockBlogPages,
+  generateMockCategories,
   generateMockSlugPages,
   getMockHomePageData,
 } from "../utils/mock-data";
@@ -94,6 +95,15 @@ async function createData() {
   console.log(`✅ Created ${faqs.length} FAQs`);
   console.log("\n");
 
+  console.log("🏷️ Generating categories...");
+  const categories = generateMockCategories();
+
+  for (const category of categories) {
+    transaction.create(category);
+  }
+  console.log(`✅ Created ${categories.length} categories`);
+  console.log("\n");
+
   console.log("⚙️ Generating global settings...");
   const settings = generateGlobalSettingsData(logo?.id);
 
@@ -127,6 +137,7 @@ async function createData() {
   const blogPages = generateMockBlogPages({
     imagesStore,
     authors: authorsPayloads,
+    categories,
   });
 
   for (const page of blogPages) {

--- a/apps/studio/utils/mock-data.ts
+++ b/apps/studio/utils/mock-data.ts
@@ -367,16 +367,60 @@ export function generateMockAuthors(imagesStore: ImageStore) {
   });
 }
 
+export function generateMockCategories() {
+  const categories = [
+    {
+      name: "Sanity",
+      description: "Content management and development with Sanity CMS",
+      color: "blue",
+    },
+    {
+      name: "Next.js",
+      description: "React framework for production applications",
+      color: "green",
+    },
+    {
+      name: "Web Development",
+      description: "General web development topics and tutorials",
+      color: "purple",
+    },
+    {
+      name: "Design",
+      description: "UI/UX design principles and best practices",
+      color: "orange",
+    },
+    {
+      name: "Performance",
+      description: "Website performance optimization and best practices",
+      color: "red",
+    },
+  ];
+
+  return categories.map((category) => ({
+    _id: faker.string.uuid(),
+    _type: "category" as const,
+    name: category.name,
+    description: category.description,
+    slug: {
+      type: "slug",
+      current: slugify(category.name, { lower: true }),
+    },
+    color: category.color,
+  }));
+}
+
 type Author = ReturnType<typeof generateMockAuthors>[number];
 
 interface BlogPageGenerationOptions {
   imagesStore: ImageStore;
   authors: Author[];
+  categories: ReturnType<typeof generateMockCategories>;
 }
 
 export function generateMockBlogPages({
   imagesStore,
   authors,
+  categories,
 }: BlogPageGenerationOptions) {
   const length = faker.number.int({ min: 2, max: 5 });
   const blogImages = imagesStore.filter((image) => image.type === "blog");
@@ -385,6 +429,8 @@ export function generateMockBlogPages({
     const title = generatePageTitle();
     const author = faker.helpers.arrayElement(authors);
     const image = faker.helpers.arrayElement(blogImages);
+    // Randomly assign 1-3 categories to each blog post
+    const selectedCategories = faker.helpers.arrayElements(categories, { min: 1, max: 3 });
 
     return {
       _id: faker.string.uuid(),
@@ -420,6 +466,11 @@ export function generateMockBlogPages({
           _ref: author._id,
         },
       ],
+      categories: selectedCategories.map((category) => ({
+        _key: faker.string.uuid(),
+        _type: "reference",
+        _ref: category._id,
+      })),
     };
   });
 }

--- a/apps/web/src/app/blog/page.tsx
+++ b/apps/web/src/app/blog/page.tsx
@@ -1,15 +1,20 @@
 import { notFound } from "next/navigation";
 
 import { BlogCard, BlogHeader, FeaturedBlogCard } from "@/components/blog-card";
+import { CategoryNavigation } from "@/components/category-navigation";
 import { PageBuilder } from "@/components/pagebuilder";
 import { SimpleSearch } from "@/components/search/simple-search";
 import { sanityFetch } from "@/lib/sanity/live";
-import { queryBlogIndexPageData } from "@/lib/sanity/query";
+import { queryBlogIndexPageData, queryCategories } from "@/lib/sanity/query";
 import { getSEOMetadata } from "@/lib/seo";
 import { handleErrors } from "@/utils";
 
 async function fetchBlogPosts() {
   return await handleErrors(sanityFetch({ query: queryBlogIndexPageData }));
+}
+
+async function fetchCategories() {
+  return await handleErrors(sanityFetch({ query: queryCategories }));
 }
 
 export async function generateMetadata() {
@@ -32,7 +37,11 @@ export async function generateMetadata() {
 
 export default async function BlogIndexPage() {
   const [res, err] = await fetchBlogPosts();
+  const [categoriesRes, categoriesErr] = await fetchCategories();
+  
   if (err || !res?.data) notFound();
+  
+  const categories = categoriesErr ? [] : categoriesRes?.data || [];
 
   const {
     blogs = [],
@@ -79,6 +88,13 @@ export default async function BlogIndexPage() {
     <main className="bg-background">
       <div className="container my-16 mx-auto px-4 md:px-6">
         <BlogHeader title={title} description={description} />
+        
+        {/* Category Navigation */}
+        {categories.length > 0 && (
+          <div className="mt-8 mb-6">
+            <CategoryNavigation categories={categories} />
+          </div>
+        )}
         
         {/* Search Component */}
         <div className="mt-8 mb-12">

--- a/apps/web/src/app/category/[slug]/page.tsx
+++ b/apps/web/src/app/category/[slug]/page.tsx
@@ -1,0 +1,121 @@
+import { notFound } from "next/navigation";
+
+import { BlogCard, BlogHeader } from "@/components/blog-card";
+import { CategoryNavigation } from "@/components/category-navigation";
+import { PageBuilder } from "@/components/pagebuilder";
+import { SimpleSearch } from "@/components/search/simple-search";
+import { sanityFetch } from "@/lib/sanity/live";
+import { client } from "@/lib/sanity/client";
+import { queryBlogsByCategory, queryCategories, queryCategoryBySlug } from "@/lib/sanity/query";
+import { getSEOMetadata } from "@/lib/seo";
+import { handleErrors } from "@/utils";
+
+interface CategoryPageProps {
+  params: Promise<{ slug: string }>;
+}
+
+
+
+export async function generateMetadata({ params }: CategoryPageProps) {
+  const { slug } = await params;
+  const { data: categoryData } = await sanityFetch({ 
+    query: queryCategoryBySlug, 
+    params: { slug },
+    stega: false,
+  });
+  
+  if (!categoryData) {
+    return getSEOMetadata({
+      title: "Category Not Found",
+      description: "The requested category could not be found.",
+    });
+  }
+
+  const { name, description } = categoryData;
+  return getSEOMetadata({
+    title: `${name} - Blog Posts`,
+    description: description || `Browse all blog posts in the ${name} category.`,
+    slug: `/category/${slug}`,
+  });
+}
+
+export async function generateStaticParams() {
+  try {
+    const categories = await client.fetch(queryCategories);
+    
+    if (!categories || !Array.isArray(categories) || categories.length === 0) {
+      return [];
+    }
+    
+    const validSlugs = categories
+      .filter((category: any) => category?.slug?.current)
+      .map((category: any) => {
+        return { slug: category.slug.current };
+      });
+    
+    return validSlugs;
+    
+  } catch (error) {
+    return [];
+  }
+}
+
+export default async function CategoryPage({ params }: CategoryPageProps) {
+  const { slug } = await params;
+  
+  // Fetch category data
+  const { data: categoryData } = await sanityFetch({ 
+    query: queryCategoryBySlug, 
+    params: { slug } 
+  });
+  
+  // Fetch categories for navigation
+  const { data: categories } = await sanityFetch({ query: queryCategories });
+  
+  // Fetch blogs for this category
+  const { data: blogs } = await sanityFetch({ 
+    query: queryBlogsByCategory, 
+    params: { category: slug } 
+  });
+
+  if (!categoryData) {
+    notFound();
+  }
+
+  return (
+    <main className="bg-background">
+      <div className="container my-16 mx-auto px-4 md:px-6">
+        <BlogHeader 
+          title={`${categoryData.name} Posts`} 
+          description={categoryData.description || `All blog posts in the ${categoryData.name} category.`} 
+        />
+        
+        {/* Category Navigation */}
+        {categories.length > 0 && (
+          <div className="mt-8 mb-6">
+            <CategoryNavigation categories={categories} />
+          </div>
+        )}
+        
+        {/* Search Component */}
+        <div className="mt-8 mb-12">
+          <SimpleSearch blogs={blogs} />
+        </div>
+
+        {blogs.length > 0 ? (
+          <div className="grid grid-cols-1 gap-8 md:gap-12 lg:grid-cols-2 mt-8">
+            {blogs.map((blog: any) => (
+              <BlogCard key={blog._id} blog={blog} />
+            ))}
+          </div>
+        ) : (
+          <div className="text-center py-12">
+            <p className="text-muted-foreground">
+              No blog posts found in this category.
+            </p>
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/components/blog-card.tsx
+++ b/apps/web/src/components/blog-card.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 
 import type { QueryBlogIndexPageDataResult } from "@/lib/sanity/sanity.types";
 
+import { Badge } from "@workspace/ui/components/badge";
 import { SanityImage } from "./sanity-image";
 
 type Blog = NonNullable<
@@ -80,6 +81,38 @@ function BlogMeta({ publishedAt }: { publishedAt: string | null }) {
   );
 }
 
+function CategoryBadges({ categories }: { categories: Blog["categories"] }) {
+  if (!categories || categories.length === 0) return null;
+
+  const colorVariants = {
+    blue: "bg-blue-100 text-blue-800 border-blue-200",
+    green: "bg-green-100 text-green-800 border-green-200",
+    purple: "bg-purple-100 text-purple-800 border-purple-200",
+    orange: "bg-orange-100 text-orange-800 border-orange-200",
+    red: "bg-red-100 text-red-800 border-red-200",
+    yellow: "bg-yellow-100 text-yellow-800 border-yellow-200",
+    pink: "bg-pink-100 text-pink-800 border-pink-200",
+    indigo: "bg-indigo-100 text-indigo-800 border-indigo-200",
+  };
+
+  return (
+    <div className="flex flex-wrap gap-2 mb-4">
+      {categories.map((category) => {
+        const colorClass = colorVariants[category.color as keyof typeof colorVariants] || colorVariants.blue;
+        return (
+          <Badge
+            key={category._id}
+            variant="outline"
+            className={`text-xs ${colorClass}`}
+          >
+            {category.name}
+          </Badge>
+        );
+      })}
+    </div>
+  );
+}
+
 function BlogContent({
   title,
   slug,
@@ -129,13 +162,14 @@ function AuthorSection({ authors }: { authors: Blog["authors"] }) {
   );
 }
 export function FeaturedBlogCard({ blog }: BlogCardProps) {
-  const { title, publishedAt, slug, authors, description, image } = blog ?? {};
+  const { title, publishedAt, slug, authors, description, image, categories } = blog ?? {};
 
   return (
     <article className="grid grid-cols-1 lg:grid-cols-2 gap-8 w-full">
       <BlogImage image={image} title={title} />
       <div className="space-y-6">
         <BlogMeta publishedAt={publishedAt} />
+        <CategoryBadges categories={categories as any} />
         <BlogContent
           title={title}
           slug={slug}
@@ -155,14 +189,13 @@ export function BlogCard({ blog }: BlogCardProps) {
         <div className="h-48 bg-muted rounded-2xl animate-pulse" />
         <div className="space-y-2">
           <div className="h-4 w-24 bg-muted rounded animate-pulse" />
-          <div className="h-6 w-full bg-muted rounded animate-pulse" />
           <div className="h-4 w-3/4 bg-muted rounded animate-pulse" />
         </div>
       </article>
     );
   }
 
-  const { title, publishedAt, slug, authors, description, image } = blog;
+  const { title, publishedAt, slug, authors, description, image, categories } = blog;
 
   return (
     <article className="grid grid-cols-1 gap-4 w-full">
@@ -172,6 +205,7 @@ export function BlogCard({ blog }: BlogCardProps) {
       </div>
       <div className="w-full space-y-4">
         <BlogMeta publishedAt={publishedAt} />
+        <CategoryBadges categories={categories as any} />
         <BlogContent title={title} slug={slug} description={description} />
         <AuthorSection authors={authors} />
       </div>

--- a/apps/web/src/components/category-navigation.tsx
+++ b/apps/web/src/components/category-navigation.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Badge } from "@workspace/ui/components/badge";
+
+interface Category {
+  _id: string;
+  name: string;
+  slug: string;
+  color: string;
+  description?: string;
+  blogCount: number;
+}
+
+interface CategoryNavigationProps {
+  categories: Category[];
+  showAll?: boolean;
+}
+
+const colorVariants = {
+  blue: "bg-blue-100 text-blue-800 hover:bg-blue-200 border-blue-200",
+  green: "bg-green-100 text-green-800 hover:bg-green-200 border-green-200",
+  purple: "bg-purple-100 text-purple-800 hover:bg-purple-200 border-purple-200",
+  orange: "bg-orange-100 text-orange-800 hover:bg-orange-200 border-orange-200",
+  red: "bg-red-100 text-red-800 hover:bg-red-200 border-red-200",
+  yellow: "bg-yellow-100 text-yellow-800 hover:bg-yellow-200 border-yellow-200",
+  pink: "bg-pink-100 text-pink-800 hover:bg-pink-200 border-pink-200",
+  indigo: "bg-indigo-100 text-indigo-800 hover:bg-indigo-200 border-indigo-200",
+};
+
+export function CategoryNavigation({ categories, showAll = true }: CategoryNavigationProps) {
+  const pathname = usePathname();
+  const isAllActive = pathname === "/blog";
+
+  return (
+    <div className="flex flex-wrap gap-2 mb-8">
+      {showAll && (
+        <Link href="/blog">
+          <Badge
+            variant="outline"
+            className={`cursor-pointer transition-colors ${
+              isAllActive
+                ? "bg-primary text-primary-foreground hover:bg-primary/90"
+                : "hover:bg-muted"
+            }`}
+          >
+            All Posts
+          </Badge>
+        </Link>
+      )}
+      
+      {categories.map((category) => {
+        const isActive = pathname === `/category/${category.slug}`;
+        const colorClass = colorVariants[category.color as keyof typeof colorVariants] || colorVariants.blue;
+        
+        return (
+          <Link key={category._id} href={`/category/${category.slug}`}>
+            <Badge
+              variant="outline"
+              className={`cursor-pointer transition-colors border ${
+                isActive
+                  ? "bg-primary text-primary-foreground hover:bg-primary/90"
+                  : colorClass
+              }`}
+            >
+              {category.name}
+              <span className="ml-1 text-xs opacity-75">({category.blogCount})</span>
+            </Badge>
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/lib/sanity/query.ts
+++ b/apps/web/src/lib/sanity/query.ts
@@ -56,7 +56,13 @@ const blogCardFragment = /* groq */ `
   orderRank,
   ${imageFragment},
   publishedAt,
-  ${blogAuthorFragment}
+  ${blogAuthorFragment},
+  "categories": categories[]->{
+    _id,
+    name,
+    "slug": slug.current,
+    color
+  }
 `;
 
 const buttonsFragment = /* groq */ `
@@ -236,6 +242,33 @@ export const queryBlogSlugPageData = defineQuery(`
 
 export const queryBlogPaths = defineQuery(`
   *[_type == "blog" && defined(slug.current)].slug.current
+`);
+
+export const queryCategories = defineQuery(`
+  *[_type == "category"] | order(name asc){
+    _id,
+    name,
+    "slug": slug.current,
+    color,
+    description,
+    "blogCount": count(*[_type == "blog" && references(^._id) && (seoHideFromLists != true)])
+  }
+`);
+
+export const queryBlogsByCategory = defineQuery(`
+  *[_type == "blog" && (seoHideFromLists != true) && $category in categories[]->slug.current] | order(orderRank asc){
+    ${blogCardFragment}
+  }
+`);
+
+export const queryCategoryBySlug = defineQuery(`
+  *[_type == "category" && slug.current == $slug][0]{
+    _id,
+    name,
+    "slug": slug.current,
+    color,
+    description
+  }
 `);
 
 const ogFieldsFragment = /* groq */ `


### PR DESCRIPTION
- Introduced a new `category` document type with fields for name, description, slug, and color.
- Updated the `blog` schema to include a `categories` field, allowing multiple category selections for each blog post.
- Implemented category creation script to generate sample categories.
- Enhanced data generation scripts to include categories in blog posts.
- Added category navigation and display components in the blog and category pages.
- Updated queries to fetch categories and blogs by category.

## Description

<!-- Brief description of changes -->

## Type of change

- [ ] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Documentation

## Screenshots (if applicable)

<!-- Screenshots of visual changes -->

## Testing

<!-- How were these changes tested? -->

## Related issues

<!-- Reference any related issues (e.g., Fixes #123) -->
